### PR TITLE
Include plot of Principal Strains

### DIFF
--- a/muDIC/mesh/meshUtilities.py
+++ b/muDIC/mesh/meshUtilities.py
@@ -143,7 +143,6 @@ def make_grid_Q4(c1x, c1y, c2x, c2y, nx, ny, elm):
 
     return np.array(con_matrix).transpose(), xnode, ynode
 
-
 def make_grid(c1x, c1y, c2x, c2y, ny, nx, elm):
     """
     Makes regular grid for the given corner coordinates, number of elements along each axis and finite element


### PR DESCRIPTION
With this PR I included a few features:
- add the possibility to plot principal strains as contour
- add the possibility to add title to the plots
- add the possibility to specify the output resolution and the size of the figure
- add the len function to the Fields object returning the number of frames saved (useful for instance to save all pictures in a loop after doing the dic analysis).

I worked over the dev branch because I wanted to use the implemented csv exporting and save_path which were not available in master branch.